### PR TITLE
Add extra plugin information to payment redirect request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 - 2023-**-**
+## 0.1.2 - 2024-02-05
 
-- initial release
+- Added information about PHP and CMS versions to payment request.

--- a/src/Entity/Request/PaymentRedirectRequest.php
+++ b/src/Entity/Request/PaymentRedirectRequest.php
@@ -138,6 +138,9 @@ class PaymentRedirectRequest implements RequestInterface
         $this->test = false;
         $this->buyerConsent = false;
         $this->timeLimit = null;
+        $this->pluginName = null;
+        $this->pluginVersion = null;
+        $this->cmsVersion = null;
     }
 
     public function getProjectId(): int

--- a/src/Entity/Request/PaymentRedirectRequest.php
+++ b/src/Entity/Request/PaymentRedirectRequest.php
@@ -99,6 +99,21 @@ class PaymentRedirectRequest implements RequestInterface
      */
     private ?string $timeLimit;
 
+    /**
+     * This parameter indicates the Paysera plugin name that is initiating the request.
+     */
+    private ?string $pluginName;
+
+    /**
+     * This parameter indicates the version of the Paysera plugin that is initiating the request.
+     */
+    private ?string $pluginVersion;
+
+    /**
+     * The parameter indicates the version of the CMS that is initiating the request.
+     */
+    private ?string $cmsVersion;
+
     private Order $order;
 
     public function __construct(
@@ -253,5 +268,41 @@ class PaymentRedirectRequest implements RequestInterface
     public function getOrder(): Order
     {
         return $this->order;
+    }
+
+    public function getPluginName(): ?string
+    {
+        return $this->pluginName;
+    }
+
+    public function setPluginName(?string $pluginName): self
+    {
+        $this->pluginName = $pluginName;
+
+        return $this;
+    }
+
+    public function getPluginVersion(): ?string
+    {
+        return $this->pluginVersion;
+    }
+
+    public function setPluginVersion(?string $pluginVersion): self
+    {
+        $this->pluginVersion = $pluginVersion;
+
+        return $this;
+    }
+
+    public function getCmsVersion(): ?string
+    {
+        return $this->cmsVersion;
+    }
+
+    public function setCmsVersion(?string $cmsVersion): self
+    {
+        $this->cmsVersion = $cmsVersion;
+
+        return $this;
     }
 }

--- a/src/Provider/WebToPay/Adapter/PaymentRedirectRequestNormalizer.php
+++ b/src/Provider/WebToPay/Adapter/PaymentRedirectRequestNormalizer.php
@@ -34,6 +34,10 @@ class PaymentRedirectRequestNormalizer
             'test' => (int) $request->getTest(),
             'buyer_consent' => (int) $request->getBuyerConsent(),
             'time_limit' => $request->getTimeLimit(),
+            'plugin_name' => $request->getPluginName(),
+            'plugin_version' => $request->getPluginVersion(),
+            'cms_version' => $request->getCmsVersion(),
+            'php_version' => phpversion(),
         ];
 
         return array_filter($paymentData, static fn ($value) => $value !== null);

--- a/tests/Provider/WebToPay/Adapter/PaymentRedirectRequestNormalizerTest.php
+++ b/tests/Provider/WebToPay/Adapter/PaymentRedirectRequestNormalizerTest.php
@@ -49,6 +49,10 @@ class PaymentRedirectRequestNormalizerTest extends AbstractCase
                 'test' => 1,
                 'buyer_consent' => 1,
                 'time_limit' => 'limit',
+                'php_version' => phpversion(),
+                'plugin_name' => 'plugin',
+                'plugin_version' => '1',
+                'cms_version' => '2',
             ],
             $data
         );
@@ -68,12 +72,18 @@ class PaymentRedirectRequestNormalizerTest extends AbstractCase
     {
         $request = $this->getRequest()
             ->setPaymentText(null)
-            ->setCountry(null);
+            ->setCountry(null)
+            ->setPluginName(null)
+            ->setPluginVersion(null)
+            ->setCmsVersion(null);
 
         $data = $this->normalizer->normalize($request);
 
         $this->assertArrayNotHasKey('paytext', $data);
         $this->assertArrayNotHasKey('country', $data);
+        $this->assertArrayNotHasKey('plugin_name', $data);
+        $this->assertArrayNotHasKey('plugin_version', $data);
+        $this->assertArrayNotHasKey('cms_version', $data);
     }
 
     protected function getRequest(): PaymentRedirectRequest
@@ -103,7 +113,10 @@ class PaymentRedirectRequestNormalizerTest extends AbstractCase
             ->setPaymentText('payment text')
             ->setTest(true)
             ->setBuyerConsent(true)
-            ->setTimeLimit('limit');
+            ->setTimeLimit('limit')
+            ->setPluginName('plugin')
+            ->setPluginVersion('1')
+            ->setCmsVersion('2');
 
         return $request;
     }

--- a/tests/Provider/WebToPay/WebToPayProviderTest.php
+++ b/tests/Provider/WebToPay/WebToPayProviderTest.php
@@ -252,6 +252,7 @@ class WebToPayProviderTest extends AbstractCase
             'p_countrycode' => 'gb',
             'test' => 1,
             'buyer_consent' => 0,
+            'php_version' => phpversion(),
         ];
 
         return [$redirectRequest, $providerData];


### PR DESCRIPTION
### General
Extra plugin information such as `php_version`, `cms_version`, `plugin_name`, `plugin_version` need to be sent via payment redirect request.

### Testing
Needs to be tested as an integrated dependency for one of the plugins. Need to check if payment request hash contains all the information.